### PR TITLE
Hotfix for action_buffer.rs

### DIFF
--- a/carla/src/traffic_manager/action_buffer.rs
+++ b/carla/src/traffic_manager/action_buffer.rs
@@ -39,7 +39,12 @@ impl ActionBuffer {
     }
 
     pub(crate) fn as_slice(&self) -> &[FfiAction] {
-        let ptr = self.inner.as_ptr();
+        // Get a &FfiActionBuffer then call its as_ptr() -> *const FfiAction
+        let ptr = self
+            .inner
+            .as_ref()
+            .expect("ActionBuffer pointer must be non-null")
+            .as_ptr();
         unsafe { slice::from_raw_parts(ptr, self.len()) }
     }
 


### PR DESCRIPTION
Hey there 👋 we're using your `carla` crate for a building block in a hackathon sandbox.

I noticed this error when building:

```
   Compiling carla v0.11.1
error[E0308]: mismatched types
  --> /home/dev/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/carla-0.11.1/src/traffic_manager/action_buffer.rs:43:40
   |
43 |         unsafe { slice::from_raw_parts(ptr, self.len()) }
   |                  --------------------- ^^^ expected *const FfiAction, found *const FfiActionBuffer
   |                  |
   |                  arguments to this function are incorrect
   |
   = note: expected raw pointer *const FfiAction
              found raw pointer *const FfiActionBuffer
note: function defined here
  --> /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/slice/raw.rs:124:21

For more information about this error, try rustc --explain E0308.
error: could not compile carla (lib) due to 1 previous error
```

This may not be the full story, I'm very new to CARLA.

However, it does get the build to pass, so I thought to open a PR with this change.